### PR TITLE
Fix logger in TranslationData

### DIFF
--- a/Mindbox.I18n/TranslationData.cs
+++ b/Mindbox.I18n/TranslationData.cs
@@ -83,7 +83,7 @@ internal class TranslationData
 					}
 					catch (Exception e)
 					{
-						logger.LogError($"Error loading file {filePath}", e);
+						logger.LogError(e, $"Error loading file {filePath}");
 						return new Dictionary<string, string>();
 					}
 				});


### PR DESCRIPTION
- https://github.com/mindbox-moscow/issues-self-service/issues/1452

Из-за неправильного порядка параметров вызывалась неправильная перегрузка метода, в результате innerException не логировался